### PR TITLE
Fix typo: package.son to package.json in documentation of unplugin-tailwindcss-mangle

### DIFF
--- a/packages/unplugin-tailwindcss-mangle/README.md
+++ b/packages/unplugin-tailwindcss-mangle/README.md
@@ -54,7 +54,7 @@ npx tw-patch install
 
 ### 4. Run extract command
 
-cd to the same directory as `package.son` and `tailwind.config.js`, then run:
+cd to the same directory as `package.json` and `tailwind.config.js`, then run:
 
 ```sh
 npx tw-patch extract


### PR DESCRIPTION
In the installation instructions of `unplugin-tailwindcss-mangle` package, I fixed a typo where `package.son` was incorrectly mentioned instead of `package.json.` This correction ensures clarity and helps prevent any confusion during the setup process.